### PR TITLE
Possible Mac mini model correction

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ What OC4VM cannot do:
 * Use the Apple para-virtualised GPU on non-Apple hardware
 * Use the Apple para-virtualised GPU on older Macs using OCLP and macOS Sonoma or later
 
-The OC4VM system has been tested on an Intel Mac mini mid-2014 and an AMD Ryzen based HP T740
+The OC4VM system has been tested on an Intel Mac mini (Late 2014) and an AMD Ryzen based HP T740
 with these guest OSes:
 * Big Sur
 * Monterey


### PR DESCRIPTION
Changed "Mac mini mid-2014" to "Mac mini (Late 2014)", as it was the only model released in 2014. The last "Mid"-designated model was in 2011. Apologies if the correction should point to some other model; here is a list stretching from 2009 to 2024: https://support.apple.com/en-us/102852